### PR TITLE
Viewer triggeredoscilloscope

### DIFF
--- a/example/pyaudio_triggerscope.py
+++ b/example/pyaudio_triggerscope.py
@@ -1,0 +1,65 @@
+"""
+Simple demonstration of streaming data from a PyAudio device to a QOscilloscope
+viewer.
+
+Both device and viewer nodes are created locally without a manager.
+"""
+
+from pyacq.devices.audio_pyaudio import PyAudio
+from pyacq.viewers import QTriggeredOscilloscope
+import pyqtgraph as pg
+
+
+# Start Qt application
+app = pg.mkQApp()
+
+
+# Create PyAudio device node
+dev = PyAudio()
+
+# Print a list of available input devices (but ultimately we will just use the 
+# default device).
+default_input = dev.default_input_device()
+print("\nAvaliable devices:")
+for device in dev.list_device_specs():
+    index = device['index']
+    star = "*" if index == default_input else " "
+    print("  %s %d: %s" % (star, index, device['name']))
+
+# Configure PyAudio device with a single (default) input channel.
+dev.configure(nb_channel=1, sample_rate=44100., input_device_index=default_input,
+              format='int16', chunksize=1024)
+dev.output.configure(protocol='tcp', interface='127.0.0.1', transfertmode='plaindata')
+dev.initialize()
+
+
+# Create a triggered oscilloscope to display data.
+viewer = QTriggeredOscilloscope()
+viewer.configure(with_user_dialog = True)
+
+# Connect audio stream to oscilloscope
+viewer.input.connect(dev.output)
+
+viewer.initialize()
+viewer.show()
+#viewer.params['decimation_method'] = 'min_max'
+#viewer.by_channel_params['Signal0', 'gain'] = 0.001
+
+viewer.trigger.params['threshold'] = 1.
+viewer.trigger.params['debounce_mode'] = 'after-stable'
+viewer.trigger.params['front'] = '+'
+viewer.trigger.params['debounce_time'] = 0.1
+viewer.triggeraccumulator.params['stack_size'] = 3
+viewer.triggeraccumulator.params['left_sweep'] = -.2
+viewer.triggeraccumulator.params['right_sweep'] = .5
+
+
+# Start both nodes
+dev.start()
+viewer.start()
+
+
+if __name__ == '__main__':
+    import sys
+    if sys.flags.interactive == 0:
+        app.exec_()

--- a/pyacq/viewers/__init__.py
+++ b/pyacq/viewers/__init__.py
@@ -1,3 +1,4 @@
 from .imageviewer import ImageViewer
 from .qoscilloscope import QOscilloscope
 from .qtimefreq import TimeFreqWorker, QTimeFreq
+from .qtriggeredoscilloscope import QTriggeredOscilloscope

--- a/pyacq/viewers/qoscilloscope.py
+++ b/pyacq/viewers/qoscilloscope.py
@@ -69,8 +69,8 @@ class BaseOscilloscope(WidgetNode):
         
         self.all_mean, self.all_sd = None, None
         
-    def show_params_controler(self):
-        self.params_controler.show()
+    def show_params_controller(self):
+        self.params_controller.show()
         # TODO deal with modality
     
     def _configure(self, with_user_dialog=True):
@@ -122,12 +122,12 @@ class BaseOscilloscope(WidgetNode):
         self.all_params.sigTreeStateChanged.connect(self.on_param_change)
         
         
-        if self.with_user_dialog and self._ControlerClass:
-            self.params_controler = self._ControlerClass(parent=self, viewer=self)
-            self.params_controler.setWindowFlags(QtCore.Qt.Window)
-            self.viewBox.doubleclicked.connect(self.show_params_controler)
+        if self.with_user_dialog and self._ControllerClass:
+            self.params_controller = self._ControllerClass(parent=self, viewer=self)
+            self.params_controller.setWindowFlags(QtCore.Qt.Window)
+            self.viewBox.doubleclicked.connect(self.show_params_controller)
         else:
-            self.params_controler = None
+            self.params_controller = None
         
         
         # poller
@@ -156,7 +156,7 @@ class BaseOscilloscope(WidgetNode):
         if self.running():
             self.stop()
         if self.with_user_dialog:
-            self.params_controler.close()
+            self.params_controller.close()
 
     def _on_new_data(self, pos, data):
         self._head = pos
@@ -189,7 +189,7 @@ class BaseOscilloscope(WidgetNode):
         if newsize>limits[0] and newsize<limits[1]:
             self.params['xsize'] = newsize
 
-class OscilloscopeControler(QtGui.QWidget):
+class OscilloscopeController(QtGui.QWidget):
     def __init__(self, parent=None, viewer=None):
         QtGui.QWidget.__init__(self, parent)
         
@@ -316,7 +316,7 @@ class QOscilloscope(BaseOscilloscope):
     _default_params = default_params
     _default_by_channel_params = default_by_channel_params
     
-    _ControlerClass = OscilloscopeControler
+    _ControllerClass = OscilloscopeController
     
     def __init__(self, **kargs):
         BaseOscilloscope.__init__(self, **kargs)
@@ -325,7 +325,7 @@ class QOscilloscope(BaseOscilloscope):
         self.viewBox.xsize_zoom.connect(self.xsize_zoom)
     
     def _configure(self, with_user_dialog=True, max_xsize=60.):
-        BaseOscilloscope._configure(self, with_user_dialog = with_user_dialog)
+        BaseOscilloscope._configure(self, with_user_dialog=with_user_dialog)
         self.max_xsize = max_xsize
 
     def _initialize(self):

--- a/pyacq/viewers/qtimefreq.py
+++ b/pyacq/viewers/qtimefreq.py
@@ -111,8 +111,8 @@ class QTimeFreq(WidgetNode):
         self.graphiclayout = pg.GraphicsLayoutWidget()
         self.mainlayout.addWidget(self.graphiclayout)
         
-    def show_params_controler(self):
-        self.params_controler.show()
+    def show_params_controller(self):
+        self.params_controller.show()
     
     def _configure(self, with_user_dialog=True, max_xsize=60., nodegroup_friends=None):
         self.with_user_dialog = with_user_dialog
@@ -223,10 +223,10 @@ class QTimeFreq(WidgetNode):
         self.all_params.sigTreeStateChanged.connect(self.on_param_change)
         
         if self.with_user_dialog:
-            self.params_controler = TimeFreqControler(parent=self, viewer=self)
-            self.params_controler.setWindowFlags(QtCore.Qt.Window)
+            self.params_controller = TimeFreqController(parent=self, viewer=self)
+            self.params_controller.setWindowFlags(QtCore.Qt.Window)
         else:
-            self.params_controler = None
+            self.params_controller = None
         
         self.create_grid()
         self.initialize_time_freq()
@@ -258,7 +258,7 @@ class QTimeFreq(WidgetNode):
         if self.running():
             self.stop()
         if self.with_user_dialog:
-            self.params_controler.close()
+            self.params_controller.close()
         for worker in self.workers:
             worker.close()
         self.conv.close()
@@ -284,7 +284,7 @@ class QTimeFreq(WidgetNode):
 
             viewBox = MyViewBox()
             if self.with_user_dialog:
-                viewBox.doubleclicked.connect(self.show_params_controler)
+                viewBox.doubleclicked.connect(self.show_params_controller)
             viewBox.gain_zoom.connect(self.clim_zoom)
             viewBox.xsize_zoom.connect(self.xsize_zoom)
             
@@ -662,7 +662,7 @@ register_node_type(TimeFreqWorker)
 
 
 
-class TimeFreqControler(QtGui.QWidget):
+class TimeFreqController(QtGui.QWidget):
     """
     GUI controller for QTimeFreq.
     """

--- a/pyacq/viewers/qtriggeredoscilloscope.py
+++ b/pyacq/viewers/qtriggeredoscilloscope.py
@@ -4,15 +4,15 @@ import pyqtgraph as pg
 import numpy as np
 
 
-from .qoscilloscope import BaseOscilloscope, OscilloscopeControler
+from .qoscilloscope import BaseOscilloscope, OscilloscopeController
 from ..core import (register_node_type,  StreamConverter)
 from ..dsp import AnalogTrigger, TriggerAccumulator
 
 
 
-class TriggeredOscilloscopeControler(OscilloscopeControler):
+class TriggeredOscilloscopeController(OscilloscopeController):
     def __init__(self, parent=None, viewer=None):
-        OscilloscopeControler.__init__(self, parent=parent, viewer=viewer)
+        OscilloscopeController.__init__(self, parent=parent, viewer=viewer)
 
 
         self.tree_params2 = pg.parametertree.ParameterTree()
@@ -43,7 +43,7 @@ class QTriggeredOscilloscope(BaseOscilloscope):
                     {'name': 'visible', 'type': 'bool', 'value': True},
                 ]
     
-    _ControlerClass = TriggeredOscilloscopeControler
+    _ControllerClass = TriggeredOscilloscopeController
     
     def __init__(self, **kargs):
         BaseOscilloscope.__init__(self, **kargs)


### PR DESCRIPTION
- Added QTriggeredOscilloscope to default imports
- Added triggered oscilloscope example (broken)
- Spelling correction

The example is broken because BaseOscilloscope requires `self.max_xsize`, which is defined in QOscilloscope.
